### PR TITLE
fix: update gatsby-remark-related-posts to v0.0.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1842,6 +1842,11 @@
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-0.0.30.tgz",
       "integrity": "sha512-orGL5LXERPYsLov6CWs3Fh6203+dXzJkR7OnddIr2514Hsecwc8xRpzCapshBbKFImCsvS/mk6+FWiN5LyZJAQ=="
     },
+    "@types/doublearray": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/doublearray/-/doublearray-0.0.29.tgz",
+      "integrity": "sha1-PL5rthavUkZI1EC733hOnB40AJ0="
+    },
     "@types/eslint-visitor-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
@@ -1851,6 +1856,14 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
       "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g=="
+    },
+    "@types/fs-extra": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.1.tgz",
+      "integrity": "sha512-B42Sxuaz09MhC3DDeW5kubRcQ5by4iuVQ0cRRWM2lggLzAa/KVom0Aft/208NgMvNQQZ86s5rVcqDdn/SH0/mg==",
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/get-port": {
       "version": "3.2.0",
@@ -1919,6 +1932,14 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
     },
+    "@types/kuromoji": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@types/kuromoji/-/kuromoji-0.1.0.tgz",
+      "integrity": "sha512-gEAkIk4qxsK5ry64fCYFGjb3a+NQVOiNOT6fz0OyXizob+yewF4GFVX23GG4YNwKM2hB0J6fnMPMffFK+cYHnw==",
+      "requires": {
+        "@types/doublearray": "*"
+      }
+    },
     "@types/lodash": {
       "version": "4.14.161",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.161.tgz",
@@ -1949,6 +1970,14 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-0.5.2.tgz",
       "integrity": "sha512-U5icWpv7YnZYGsN4/cmh3WD2onMY0aJIiTE6+51TwJCttdHvtCYmkBNOobHlXwrJRL0nkH9jH4kD+1FAdMN4Tg==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/natural": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/natural/-/natural-2.1.0.tgz",
+      "integrity": "sha512-R/HWzH71wilqo3idmqIAmeJ4dvDnvcOl7z7dV/d/6c+Wz5QB6wdBSLcpQYClkQa2vhxbdZp8uPkYN4Z+ByIjhQ==",
       "requires": {
         "@types/node": "*"
       }
@@ -7553,15 +7582,20 @@
       }
     },
     "gatsby-remark-related-posts": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/gatsby-remark-related-posts/-/gatsby-remark-related-posts-0.0.7.tgz",
-      "integrity": "sha512-9JvEhVMrMdMV91AAJlNAFC7eILphmnZfSi81cXonhl6qD/G16RUl1YJnNCnom1ZIOvQp2LLw461J9BelRvTsvA==",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/gatsby-remark-related-posts/-/gatsby-remark-related-posts-0.0.8.tgz",
+      "integrity": "sha512-azTBQk5rBIF9AdMH8nC0CjTJ2riE3MqxB7kuDP9s3OSpljjFYiUccLPTa8c7xiKf+Htrmtq/cw85a7Zmr7XmGg==",
       "requires": {
+        "@types/fs-extra": "^9.0.1",
+        "@types/glob": "^7.1.3",
+        "@types/kuromoji": "^0.1.0",
+        "@types/natural": "^2.1.0",
         "compute-cosine-similarity": "^1.0.0",
-        "fs-extra": "^9.0.0",
+        "fs-extra": "^9.0.1",
         "glob": "^7.1.6",
         "kuromoji": "^0.1.2",
-        "natural": "^2.1.5"
+        "natural": "^2.1.5",
+        "typescript": "^4.0.3"
       },
       "dependencies": {
         "fs-extra": {
@@ -15560,6 +15594,11 @@
       "requires": {
         "is-typedarray": "^1.0.0"
       }
+    },
+    "typescript": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.3.tgz",
+      "integrity": "sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg=="
     },
     "unc-path-regex": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "gatsby": "^2.24.61",
-    "gatsby-remark-related-posts": "0.0.7",
+    "gatsby-remark-related-posts": "0.0.8",
     "gatsby-source-filesystem": "^2.3.30",
     "gatsby-transformer-remark": "^2.8.35",
     "react": "^16.12.0",


### PR DESCRIPTION
gatsby-remark-related-posts@0.0.8 is supporting multiple file sources.
Please update gatsby-remark-related-posts!